### PR TITLE
🐛 Fix for DbContext Options parameter

### DIFF
--- a/src/EasyProfiler.EntityFrameworkCore/ProfilerCoreDbContext.cs
+++ b/src/EasyProfiler.EntityFrameworkCore/ProfilerCoreDbContext.cs
@@ -9,7 +9,7 @@ namespace EasyProfiler.EntityFrameworkCore
 {
     public abstract class ProfilerCoreDbContext : DbContext, IEasyProfilerContext
     {
-        public ProfilerCoreDbContext(DbContextOptions<ProfilerCoreDbContext> options) : base(options)
+        public ProfilerCoreDbContext(DbContextOptions options) : base(options)
         {
         }
 

--- a/src/EasyProfiler.MariaDb/Context/DesignTimeDbContext.cs
+++ b/src/EasyProfiler.MariaDb/Context/DesignTimeDbContext.cs
@@ -8,7 +8,7 @@ namespace EasyProfiler.MariaDb.Context
     {
         public ProfilerMariaDbContext CreateDbContext(string[] args)
         {
-            var optionsBuilder = new DbContextOptionsBuilder<ProfilerCoreDbContext>();
+            var optionsBuilder = new DbContextOptionsBuilder<ProfilerMariaDbContext>();
 #if NETCOREAPP3_1
             optionsBuilder.UseMySql("----");
 #elif NET5_0_OR_GREATER

--- a/src/EasyProfiler.MariaDb/Context/ProfilerMariaDbContext.cs
+++ b/src/EasyProfiler.MariaDb/Context/ProfilerMariaDbContext.cs
@@ -10,7 +10,7 @@ namespace EasyProfiler.MariaDb.Context
     /// </summary>
     public class ProfilerMariaDbContext : ProfilerCoreDbContext
     {
-        public ProfilerMariaDbContext(DbContextOptions<ProfilerCoreDbContext> options) : base(options)
+        public ProfilerMariaDbContext(DbContextOptions<ProfilerMariaDbContext> options) : base(options)
         {
         }
 

--- a/src/EasyProfiler.PostgreSQL/Context/DesignTimeDbContext.cs
+++ b/src/EasyProfiler.PostgreSQL/Context/DesignTimeDbContext.cs
@@ -23,7 +23,7 @@ namespace EasyProfiler.PostgreSQL.Context
         /// </returns>
         public ProfilerPostgreSqlDbContext CreateDbContext(string[] args)
         {
-            var optionsBuilder = new DbContextOptionsBuilder<ProfilerCoreDbContext>();
+            var optionsBuilder = new DbContextOptionsBuilder<ProfilerPostgreSqlDbContext>();
             optionsBuilder.UseNpgsql("xxxx");
             return new ProfilerPostgreSqlDbContext(optionsBuilder.Options);
         }

--- a/src/EasyProfiler.PostgreSQL/Context/ProfilerPostgreSqlDbContext.cs
+++ b/src/EasyProfiler.PostgreSQL/Context/ProfilerPostgreSqlDbContext.cs
@@ -10,7 +10,7 @@ namespace EasyProfiler.PostgreSQL.Context
     /// </summary>
     public class ProfilerPostgreSqlDbContext : ProfilerCoreDbContext
     {
-        public ProfilerPostgreSqlDbContext(DbContextOptions<ProfilerCoreDbContext> options) : base(options)
+        public ProfilerPostgreSqlDbContext(DbContextOptions<ProfilerPostgreSqlDbContext> options) : base(options)
         {
         }
 

--- a/src/EasyProfiler.SQLServer/Context/DesignTimeDbContext.cs
+++ b/src/EasyProfiler.SQLServer/Context/DesignTimeDbContext.cs
@@ -11,7 +11,7 @@ namespace EasyProfiler.SQLServer.Context
     {
         public ProfilerSqlServerDbContext CreateDbContext(string[] args)
         {
-            var optionsBuilder = new DbContextOptionsBuilder<ProfilerCoreDbContext>();
+            var optionsBuilder = new DbContextOptionsBuilder<ProfilerSqlServerDbContext>();
             optionsBuilder.UseSqlServer("xxxx");
             return new ProfilerSqlServerDbContext(optionsBuilder.Options);
         }

--- a/src/EasyProfiler.SQLServer/Context/ProfilerSqlServerDbContext.cs
+++ b/src/EasyProfiler.SQLServer/Context/ProfilerSqlServerDbContext.cs
@@ -12,7 +12,7 @@ namespace EasyProfiler.SQLServer.Context
     /// </summary>
     public class ProfilerSqlServerDbContext : ProfilerCoreDbContext, IEasyProfilerContext
     {
-        public ProfilerSqlServerDbContext(DbContextOptions<ProfilerCoreDbContext> options) : base(options)
+        public ProfilerSqlServerDbContext(DbContextOptions<ProfilerSqlServerDbContext> options) : base(options)
         {
         }
 


### PR DESCRIPTION
## Summary
Each DbContext parameter has been set as `ProfilerCoreDbContextOptions` with PR #70 and that makes to configure separately. So that was a HUGE Change, I just revert it back and each database provider will have their own options after this PR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/furkandeveloper/easyprofiler/72)
<!-- Reviewable:end -->
