### PR TITLE
🐛 Add property conversion for `QueryType` parameter in ProfilerCoreDb…

### DIFF
--- a/src/EasyProfiler.EntityFrameworkCore/ProfilerCoreDbContext.cs
+++ b/src/EasyProfiler.EntityFrameworkCore/ProfilerCoreDbContext.cs
@@ -4,6 +4,7 @@ using EasyProfiler.Core.Abstractions;
 using EasyProfiler.Core.Entities;
 using Microsoft.EntityFrameworkCore;
 using EasyProfiler.EntityFrameworkCore.Generators;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace EasyProfiler.EntityFrameworkCore
 {
@@ -41,6 +42,10 @@ namespace EasyProfiler.EntityFrameworkCore
                 entity
                     .Property(p => p.Query)
                     .IsRequired();
+
+                entity
+                    .Property(p => p.QueryType)
+                    .HasConversion(new EnumToStringConverter<QueryType>());
                 
                 entity
                     .Property(p => p.Duration)


### PR DESCRIPTION
## Summary

This PR includes hotfix for #73 #68 #72 #70 after merge issues.

Must be added conversion property for `QueryType` field. Otherwise `EasyProfiler` have follow error;

![image](https://user-images.githubusercontent.com/47147484/115125421-9a8edd00-9fd0-11eb-941d-48d540cc1ca0.png)


fyi @enisn

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/furkandeveloper/easyprofiler/74)
<!-- Reviewable:end -->
